### PR TITLE
Use transactions and constants package in client scripts

### DIFF
--- a/cashback/client/print_sendable_cashback.js
+++ b/cashback/client/print_sendable_cashback.js
@@ -11,7 +11,8 @@ const { EPOCH_TIME } = require('@liskhq/lisk-constants');
  */
 
 const getTimestamp = () => {
-	const millisSinceEpoc = Date.now() - Date.parse(EPOCH_TIME);
+    // check config file or curl localhost:4000/api/node/constants to verify your epoc time
+    const millisSinceEpoc = Date.now() - Date.parse(EPOCH_TIME);
 	const inSeconds = ((millisSinceEpoc) / 1000).toFixed(0);
 	return  parseInt(inSeconds);
 }

--- a/hello_world/client/print_sendable_hello-world.js
+++ b/hello_world/client/print_sendable_hello-world.js
@@ -1,4 +1,6 @@
 const createSendableTransaction = require('./create_sendable_transaction_base_trs');
+const transactions = require('@liskhq/lisk-transactions');
+const { EPOCH_TIME } = require('@liskhq/lisk-constants');
 const HelloTransaction = require('../hello_transaction');
 
 /**
@@ -7,9 +9,8 @@ const HelloTransaction = require('../hello_transaction');
  *  Note: An node needs to run on port 4000 (the default one) before. If the node runs on a different port, adjust the query accordingly.
  */
 const getTimestamp = () => {
-	const epochTime = "2016-05-24T17:00:00.000Z" //default epoch time
 	// check config file or curl localhost:4000/api/node/constants to verify your epoc time
-	const millisSinceEpoc = Date.now() - Date.parse(epochTime);
+	const millisSinceEpoc = Date.now() - Date.parse(EPOCH_TIME);
 	const inSeconds = ((millisSinceEpoc) / 1000).toFixed(0);
 	return  parseInt(inSeconds);
 }
@@ -19,7 +20,7 @@ let h = createSendableTransaction(HelloTransaction, {
 	asset: {
 		hello: 'world',
 	},
-	fee: `${10 ** 8}`,
+	fee: `${transactions.utils.convertLSKToBeddows('1')}`,
 	recipientId: '10881167371402274308L', //delegate genesis_100
 	senderPublicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
 	passphrase: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',


### PR DESCRIPTION
We could use more elements packages in the client scripts, to

- showcase how to use elements packages as part of a bApp
- make the code more readable and understandable, e.g. by exchanging
`2 * (10 ** 8)` with
`transactions.utils.convertLSKToBeddows(2)`