### PR TITLE
errors should be concatenated with the result of super.applyAsset() - Closes #22

### DIFF
--- a/cashback/cashback_transaction.js
+++ b/cashback/cashback_transaction.js
@@ -10,12 +10,12 @@ class CashbackTransaction extends TransferTransaction {
 		return 11;
 	};
 
-    static get FEE () {
-        return `${10 ** 7}`;
-    };
+	static get FEE () {
+		return `${10 ** 7}`;
+	};
 
 	applyAsset(store) {
-		super.applyAsset(store);
+		const errors = super.applyAsset(store);
 
 		const sender = store.account.get(this.senderId);
 		const updatedSenderBalanceAfterBonus = new BigNum(sender.balance).add(
@@ -27,11 +27,11 @@ class CashbackTransaction extends TransferTransaction {
 		};
 		store.account.set(sender.address, updatedSender);
 
-		return [];
+		return errors;
 	}
 
 	undoAsset(store) {
-		super.undoAsset(store);
+		const errors = super.undoAsset(store);
 
 		const sender = store.account.get(this.senderId);
 		const updatedSenderBalanceAfterBonus = new BigNum(sender.balance).sub(
@@ -43,7 +43,7 @@ class CashbackTransaction extends TransferTransaction {
 		};
 		store.account.set(sender.address, updatedSender);
 
-		return [];
+		return errors;
 	}
 }
 

--- a/invoice/transactions/payment_transaction.js
+++ b/invoice/transactions/payment_transaction.js
@@ -15,8 +15,8 @@ class PaymentTransaction extends TransferTransaction {
 	 }
 
 	applyAsset(store) {
-		super.applyAsset(store);
-		const errors = [];
+		const errors = super.applyAsset(store);
+
 		const transaction = store.transaction.find(
 			transaction => transaction.id === this.asset.data
 		); // Find related invoice in transactions for invoiceID
@@ -51,9 +51,9 @@ class PaymentTransaction extends TransferTransaction {
 	undoAsset(store) {
 		// No rollback needed as there is only validation happening in applyAsset
 		// Higher level function will rollback the attempted payment (send back tokens)
-		super.undoAsset(store); 
+		const errors = super.undoAsset(store);
 	
-		return [];
+		return errors;
 	}
 
 }


### PR DESCRIPTION
Transactions extending `TranserTransaction` was ignoring errors from `super.applyAsset()`.