### PR TITLE
Remove Type from InvoiceTransaction creation

### DIFF
--- a/invoice/client/package.json
+++ b/invoice/client/package.json
@@ -30,6 +30,7 @@
     "build": "react-scripts build",
     "eslint": "eslint ./"
   },
+  "eslintIgnore": ["build"],
   "eslintConfig": {
     "extends": [
       "airbnb",

--- a/invoice/client/src/utils/api.js
+++ b/invoice/client/src/utils/api.js
@@ -66,10 +66,10 @@ export const getAccount = ({ passphrase }) => new Promise(async (resolve, reject
   }
 });
 
-const createInvoice = ({
+export const sendInvoice = ({
   client, requestedAmount, description,
-}, passphrase) => (
-  new InvoiceTransaction({
+}, passphrase) => {
+  const invoiceTx = new InvoiceTransaction({
     asset: {
       client,
       requestedAmount: transactions.utils.convertLSKToBeddows(requestedAmount),
@@ -77,39 +77,23 @@ const createInvoice = ({
     },
     recipientId: client,
     timestamp: dateToLiskEpochTimestamp(new Date()),
-  })
-);
-
-export const sendInvoice = ({
-  client, requestedAmount, description,
-}, passphrase) => {
-  const invoiceTx = createInvoice({
-    client, requestedAmount, description,
-  }, passphrase);
+  });
 
   invoiceTx.sign(passphrase);
   return getApiClient().transactions.broadcast(invoiceTx.toJSON());
 };
 
-const createPayment = ({
+export const sendPayment = ({
   recipientId, amount, invoiceID,
-}, passphrase) => (
-  new PaymentTransaction({
+}, passphrase) => {
+  const paymentTx = new PaymentTransaction({
     asset: {
       data: invoiceID,
     },
     amount: transactions.utils.convertLSKToBeddows(amount),
     recipientId,
     timestamp: dateToLiskEpochTimestamp(new Date()),
-  })
-);
-
-export const sendPayment = ({
-  recipientId, amount, invoiceID,
-}, passphrase) => {
-  const paymentTx = createPayment({
-    recipientId, amount, invoiceID,
-  }, passphrase);
+  });
 
   paymentTx.sign(passphrase);
   return getApiClient().transactions.broadcast(paymentTx.toJSON());

--- a/invoice/client/src/utils/api.js
+++ b/invoice/client/src/utils/api.js
@@ -75,8 +75,6 @@ const createInvoice = ({
       requestedAmount: transactions.utils.convertLSKToBeddows(requestedAmount),
       description,
     },
-    fee: transactions.utils.convertLSKToBeddows('1'),
-    senderPublicKey: getAddressAndPublicKeyFromPassphrase(passphrase).publicKey,
     recipientId: client,
     timestamp: dateToLiskEpochTimestamp(new Date()),
   })
@@ -97,14 +95,11 @@ const createPayment = ({
   recipientId, amount, invoiceID,
 }, passphrase) => (
   new PaymentTransaction({
-    type: PaymentTransaction.TYPE,
     asset: {
       data: invoiceID,
     },
-    fee: transactions.utils.convertLSKToBeddows('0.1'),
     amount: transactions.utils.convertLSKToBeddows(amount),
     recipientId,
-    senderPublicKey: getAddressAndPublicKeyFromPassphrase(passphrase).publicKey,
     timestamp: dateToLiskEpochTimestamp(new Date()),
   })
 );

--- a/invoice/client/src/utils/api.js
+++ b/invoice/client/src/utils/api.js
@@ -70,7 +70,6 @@ const createInvoice = ({
   client, requestedAmount, description,
 }, passphrase) => (
   new InvoiceTransaction({
-    type: InvoiceTransaction.TYPE,
     asset: {
       client,
       requestedAmount: transactions.utils.convertLSKToBeddows(requestedAmount),


### PR DESCRIPTION
By default, the InvoiceTransaction has the static getter `TYPE` so we don't have to specify the `type` parameter explicitly anymore