### PR TITLE
Remove default field in create_nft_asset.js

### DIFF
--- a/tutorials/nft/blockchain_app/nft_module/transactions/create_nft_asset.js
+++ b/tutorials/nft/blockchain_app/nft_module/transactions/create_nft_asset.js
@@ -28,12 +28,7 @@ class CreateNFTAsset extends BaseAsset {
         dataType: "string",
         fieldNumber: 3,
       },
-    },
-    default: {
-      minPurchaseMargin: 0,
-      initValue: 1,
-      name: "",
-    },
+    }
   };
   validate({asset}) {
     if (asset.initValue <= 0) {


### PR DESCRIPTION
The default field is causing HTTP 409 error with the message
`Lisk validator found 1 error[s]:\nProperty '' has extraneous property 'default'`